### PR TITLE
Added extra layer of caching / reduce load on Redis

### DIFF
--- a/library/Zend/Locale/Data.php
+++ b/library/Zend/Locale/Data.php
@@ -335,9 +335,14 @@ class Zend_Locale_Data
 
         $val = urlencode($val);
         $id  = self::_filterCacheId('Zend_LocaleL_' . $locale . '_' . $path . '_' . $val);
-        if (!self::$_cacheDisabled && ($result = self::$_cache->load($id))) {
-            return unserialize($result);
+        if (!self::$_cacheDisabled && !empty(self::$_list[$id])) {
+            return self::$_list[$id];
         }
+
+        if (!self::$_cacheDisabled && ($result = self::$_cache->load($id))) {
+            self::$_list[$id] = unserialize($result);
+            return self::$_list[$id];
+         }
 
         $temp = array();
         switch(strtolower($path)) {
@@ -984,8 +989,13 @@ class Zend_Locale_Data
         }
         $val = urlencode($val);
         $id  = self::_filterCacheId('Zend_LocaleC_' . $locale . '_' . $path . '_' . $val);
+        if (!self::$_cacheDisabled && !empty(self::$_list[$id])) {
+            return self::$_list[$id];
+        }
+
         if (!self::$_cacheDisabled && ($result = self::$_cache->load($id))) {
-            return unserialize($result);
+            self::$_list[$id] = unserialize($result);
+            return self::$_list[$id];
         }
 
         switch(strtolower($path)) {


### PR DESCRIPTION
Zend_Locale_Data returns a formatted locale string based on the input.
Once string is proceed it stored into cache storage File or Redis or Memcache or MySQL.
Every time someone is asking for the same formatted locale string, it will get it from cache. 

However, if the same execution is asking for the same locale string, it always looking into the cache storage. Ideally, we can store result in temporary variable to reduce the load on remote cache storage. 

Example:
- There is a booking website 
- There are number of providers who have their open hours
- Zend_Date function is in use to present data in correct locale
- Open hour from each provider going via Zend_Date function to display the right date / locale. 
- Page has about 20-50 providers, in some cases, the number of calls to cache storage (e.g. Redis) could jump to 22,000+ on page load.

This commit introduced a temporary variable to store a cache for a single page load.